### PR TITLE
feat : adding the pattern attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ En cas d'echec, le `Validator` leve une `Mithridatem\Validation\Exception\Valida
 - `NotBlank` : interdit les valeurs nulles ou les chaines vides
 - `Length` : impose une longueur minimale et/ou maximale
 - `Email` : valide une adresse electronique avec `FILTER_VALIDATE_EMAIL`
+- `Pattern` : impose un pattern regex à une string
 
 ## Developpement
 

--- a/src/Attributes/Pattern.php
+++ b/src/Attributes/Pattern.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Mithridatem\Validation\Attributes;
+
+use Attribute;
+use Mithridatem\Validation\Contracts\PropertyConstraint;
+use Mithridatem\Validation\Exception\ValidationException;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Pattern implements PropertyConstraint
+{
+    public function __construct(
+        private readonly string $pattern,
+    ) {
+        if (trim($this->pattern) === '') {
+            throw new \InvalidArgumentException('The pattern provided must not be empty.');
+        }
+
+        // Vérifie que le pattern est une expression régulière valide
+        if (@preg_match($this->pattern, '') === false) {
+            throw new \InvalidArgumentException(sprintf(
+                'The pattern "%s" is not a valid regular expression.',
+                $this->pattern
+            ));
+        }
+    }
+
+    public function validate(string $property, mixed $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new ValidationException(sprintf(
+                'La propriété "%s" doit être une chaîne de caractères pour être validée par une expression régulière.',
+                $property
+            ));
+        }
+
+        if (!preg_match($this->pattern, $value)) {
+            throw new ValidationException(sprintf(
+                'La propriété "%s" doit correspondre au pattern : %s.',
+                $property,
+                $this->pattern
+            ));
+        }
+    }
+}

--- a/src/Attributes/Pattern.php
+++ b/src/Attributes/Pattern.php
@@ -16,7 +16,6 @@ class Pattern implements PropertyConstraint
             throw new \InvalidArgumentException('The pattern provided must not be empty.');
         }
 
-        // Vérifie que le pattern est une expression régulière valide
         if (@preg_match($this->pattern, '') === false) {
             throw new \InvalidArgumentException(sprintf(
                 'The pattern "%s" is not a valid regular expression.',

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -5,6 +5,7 @@ namespace Mithridatem\Validation\Tests\Fixtures;
 use Mithridatem\Validation\Attributes\Email;
 use Mithridatem\Validation\Attributes\Length;
 use Mithridatem\Validation\Attributes\NotBlank;
+use Mithridatem\Validation\Attributes\Pattern;
 
 class User
 {
@@ -17,6 +18,10 @@ class User
 
     #[Email]
     private ?string $email = null;
+
+    #[Pattern(pattern: '/^[a-zA-Z0-9]+$/')]
+    private ?string $pattern = null;
+
 
     public function setFirstname(?string $firstname): void
     {
@@ -31,5 +36,10 @@ class User
     public function setEmail(?string $email): void
     {
         $this->email = $email;
+    }
+
+    public function setPattern(?string $pattern): void
+    {
+        $this->pattern = $pattern;
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -52,6 +52,34 @@ class ValidatorTest extends TestCase
         $this->validator->validate($user);
     }
 
+    public function testItPassesWhenPatternConstraintIsSatisfied(): void
+    {
+        $user = $this->createValidUser();
+        $user->setPattern('User123');
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
+
+    public function testItFailsWhenPatternConstraintIsViolated(): void
+    {
+        $user = $this->createValidUser();
+        $user->setPattern('User_123');
+
+        $this->expectException(ValidationException::class);
+        $this->validator->validate($user);
+    }
+
+    public function testItAllowsNullWhenPatternConstraintIsSet(): void
+    {
+        $user = $this->createValidUser();
+        $user->setPattern(null);
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
     private function createValidUser(): User
     {
         $user = new User();


### PR DESCRIPTION
# Ajout de l’annotation `Pattern` et des tests associés

- Création de l’attribut `#[Pattern]` pour valider qu’une chaîne correspond à une expression régulière.
- Vérification de la validité de la regex dans le constructeur pour éviter les patterns invalides.
- Mise à jour des tests unitaires pour inclure :
  - Cas où la valeur respecte le pattern.
  - Cas où la valeur ne respecte pas le pattern.
  - Cas où la valeur est `null`.
- Ajustement du fixture `User` pour inclure un champ avec l’annotation `Pattern`.
