### PR TITLE
Ajout des validateurs Negative, NegativeOrZero, Positive et PositiveOrZero 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ En cas d'echec, le `Validator` leve une `Mithridatem\Validation\Exception\Valida
 - `Length` : impose une longueur minimale et/ou maximale
 - `Email` : valide une adresse electronique avec `FILTER_VALIDATE_EMAIL`
 - `Pattern` : impose un pattern regex à une string
+- `Negative` : impose une valeur négative à un entier  
 
 ## Developpement
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ En cas d'echec, le `Validator` leve une `Mithridatem\Validation\Exception\Valida
 - `Negative` : impose une valeur négative à un entier  
 - `NegativeOrZero` : impose une valeur négative ou égale à zéro à un entier  
 - `Positive` : impose une valeur positive à un entier  
+- `PositiveOrZero` : impose une valeur positive ou égale à zéro à un entier  
 
 ## Developpement
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ En cas d'echec, le `Validator` leve une `Mithridatem\Validation\Exception\Valida
 - `Email` : valide une adresse electronique avec `FILTER_VALIDATE_EMAIL`
 - `Pattern` : impose un pattern regex à une string
 - `Negative` : impose une valeur négative à un entier  
+- `NegativeOrZero` : impose une valeur négative ou égale à zéro à un entier  
 
 ## Developpement
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ En cas d'echec, le `Validator` leve une `Mithridatem\Validation\Exception\Valida
 - `Pattern` : impose un pattern regex à une string
 - `Negative` : impose une valeur négative à un entier  
 - `NegativeOrZero` : impose une valeur négative ou égale à zéro à un entier  
+- `Positive` : impose une valeur positive à un entier  
 
 ## Developpement
 

--- a/src/Attributes/Negative.php
+++ b/src/Attributes/Negative.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Mithridatem\Validation\Attributes;
+
+use Mithridatem\Validation\Contracts\PropertyConstraint;
+use Mithridatem\Validation\Exception\ValidationException;
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Negative implements PropertyConstraint
+{
+    public function validate(string $property, mixed $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if (!is_numeric($value)) {
+            throw new ValidationException(
+                sprintf('La propriété "%s" doit être un nombre.', $property)
+            );
+        }
+
+        if ($value >= 0) {
+            throw new ValidationException(
+                sprintf('La propriété "%s" doit être un nombre négatif.', $property)
+            );
+        }
+    }
+}

--- a/src/Attributes/NegativeOrZero.php
+++ b/src/Attributes/NegativeOrZero.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Mithridatem\Validation\Attributes;
+
+use Mithridatem\Validation\Contracts\PropertyConstraint;
+use Mithridatem\Validation\Exception\ValidationException;
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class NegativeOrZero implements PropertyConstraint
+{
+    public function validate(string $property, mixed $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if (!is_numeric($value)) {
+            throw new ValidationException(
+                sprintf('La propriété "%s" doit être un nombre.', $property)
+            );
+        }
+
+        if ($value > 0) {
+            throw new ValidationException(
+                sprintf('La propriété "%s" doit être un nombre négatif ou égal à zéro.', $property)
+            );
+        }
+    }
+}

--- a/src/Attributes/Positive.php
+++ b/src/Attributes/Positive.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Mithridatem\Validation\Attributes;
+
+use Mithridatem\Validation\Contracts\PropertyConstraint;
+use Mithridatem\Validation\Exception\ValidationException;
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Positive implements PropertyConstraint
+{
+    public function validate(string $property, mixed $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if (!is_numeric($value)) {
+            throw new ValidationException(
+                sprintf('La propriété "%s" doit être un nombre.', $property)
+            );
+        }
+
+        if ($value <= 0) {
+            throw new ValidationException(
+                sprintf('La propriété "%s" doit être un nombre positif.', $property)
+            );
+        }
+    }
+}

--- a/src/Attributes/PositiveOrZero.php
+++ b/src/Attributes/PositiveOrZero.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Mithridatem\Validation\Attributes;
+
+use Mithridatem\Validation\Contracts\PropertyConstraint;
+use Mithridatem\Validation\Exception\ValidationException;
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class PositiveOrZero implements PropertyConstraint
+{
+    public function validate(string $property, mixed $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if (!is_numeric($value)) {
+            throw new ValidationException(
+                sprintf('La propriété "%s" doit être un nombre.', $property)
+            );
+        }
+
+        if ($value < 0) {
+            throw new ValidationException(
+                sprintf('La propriété "%s" doit être un nombre positif ou égal à zéro.', $property)
+            );
+        }
+    }
+}

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -5,6 +5,7 @@ namespace Mithridatem\Validation\Tests\Fixtures;
 use Mithridatem\Validation\Attributes\Email;
 use Mithridatem\Validation\Attributes\Length;
 use Mithridatem\Validation\Attributes\Negative;
+use Mithridatem\Validation\Attributes\NegativeOrZero;
 use Mithridatem\Validation\Attributes\NotBlank;
 use Mithridatem\Validation\Attributes\Pattern;
 
@@ -25,6 +26,9 @@ class User
 
     #[Negative]
     private ?int $negative = null;
+
+    #[NegativeOrZero]
+    private ?int $negativeOrZero = null;
 
     public function setFirstname(?string $firstname): void
     {
@@ -49,5 +53,10 @@ class User
     public function setNegative(?int $negative): void
     {
         $this->negative = $negative;
+    }
+
+    public function setNegativeOrZero(?int $negativeOrZero): void
+    {
+        $this->negativeOrZero = $negativeOrZero;
     }
 }

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -9,6 +9,7 @@ use Mithridatem\Validation\Attributes\NegativeOrZero;
 use Mithridatem\Validation\Attributes\NotBlank;
 use Mithridatem\Validation\Attributes\Pattern;
 use Mithridatem\Validation\Attributes\Positive;
+use Mithridatem\Validation\Attributes\PositiveOrZero;
 
 class User
 {
@@ -32,7 +33,10 @@ class User
     private ?int $negativeOrZero = null;
 
     #[Positive]
-    private ?int $postivie = null;
+    private ?int $positive = null;
+
+    #[PositiveOrZero]
+    private ?int $positiveOrZero = null;
 
     public function setFirstname(?string $firstname): void
     {
@@ -66,6 +70,12 @@ class User
 
     public function setPositive(?int $positive): void
     {
-        $this->postivie = $positive;
+        $this->positive = $positive;
+    }
+
+
+    public function setPositiveOrZero(?int $positiveOrZero): void
+    {
+        $this->positiveOrZero = $positiveOrZero;
     }
 }

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -4,6 +4,7 @@ namespace Mithridatem\Validation\Tests\Fixtures;
 
 use Mithridatem\Validation\Attributes\Email;
 use Mithridatem\Validation\Attributes\Length;
+use Mithridatem\Validation\Attributes\Negative;
 use Mithridatem\Validation\Attributes\NotBlank;
 use Mithridatem\Validation\Attributes\Pattern;
 
@@ -22,6 +23,8 @@ class User
     #[Pattern(pattern: '/^[a-zA-Z0-9]+$/')]
     private ?string $pattern = null;
 
+    #[Negative]
+    private ?int $negative = null;
 
     public function setFirstname(?string $firstname): void
     {
@@ -41,5 +44,10 @@ class User
     public function setPattern(?string $pattern): void
     {
         $this->pattern = $pattern;
+    }
+
+    public function setNegative(?int $negative): void
+    {
+        $this->negative = $negative;
     }
 }

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -8,6 +8,7 @@ use Mithridatem\Validation\Attributes\Negative;
 use Mithridatem\Validation\Attributes\NegativeOrZero;
 use Mithridatem\Validation\Attributes\NotBlank;
 use Mithridatem\Validation\Attributes\Pattern;
+use Mithridatem\Validation\Attributes\Positive;
 
 class User
 {
@@ -29,6 +30,9 @@ class User
 
     #[NegativeOrZero]
     private ?int $negativeOrZero = null;
+
+    #[Positive]
+    private ?int $postivie = null;
 
     public function setFirstname(?string $firstname): void
     {
@@ -58,5 +62,10 @@ class User
     public function setNegativeOrZero(?int $negativeOrZero): void
     {
         $this->negativeOrZero = $negativeOrZero;
+    }
+
+    public function setPositive(?int $positive): void
+    {
+        $this->postivie = $positive;
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -185,6 +185,48 @@ class ValidatorTest extends TestCase
         $this->assertTrue(true);
     }
 
+
+    public function testItPassesWhenPositiveOrZeroIsPositive(): void
+    {
+        $user = $this->createValidUser();
+        $user->setPositiveOrZero(5);
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
+
+    public function testItPassesWhenPositiveOrZeroIsZero(): void
+    {
+        $user = $this->createValidUser();
+        $user->setPositiveOrZero(0);
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
+
+    public function testItFailsWhenPositiveOrZeroIsNegative(): void
+    {
+        $user = $this->createValidUser();
+        $user->setPositiveOrZero(-3);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('doit être un nombre positif ou égal à zéro');
+
+        $this->validator->validate($user);
+    }
+
+    public function testItAllowsNullWhenPositiveOrZeroIsSet(): void
+    {
+        $user = $this->createValidUser();
+        $user->setPositiveOrZero(null);
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
+
     private function createValidUser(): User
     {
         $user = new User();

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -80,6 +80,38 @@ class ValidatorTest extends TestCase
 
         $this->assertTrue(true);
     }
+
+    public function testItPassesWhenNegativeConstraintIsSatisfied(): void
+    {
+        $user = $this->createValidUser();
+        $user->setNegative(-10);
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
+
+    public function testItFailsWhenNegativeConstraintIsViolated(): void
+    {
+        $user = $this->createValidUser();
+        $user->setNegative(5);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('doit être un nombre négatif');
+
+        $this->validator->validate($user);
+    }
+
+    public function testItAllowsNullWhenNegativeConstraintIsSet(): void
+    {
+        $user = $this->createValidUser();
+        $user->setNegative(null);
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
+
     private function createValidUser(): User
     {
         $user = new User();

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -112,6 +112,47 @@ class ValidatorTest extends TestCase
         $this->assertTrue(true);
     }
 
+    public function testItPassesWhenNegativeOrZeroIsNegative(): void
+    {
+        $user = $this->createValidUser();
+        $user->setNegativeOrZero(-5);
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
+
+    public function testItPassesWhenNegativeOrZeroIsZero(): void
+    {
+        $user = $this->createValidUser();
+        $user->setNegativeOrZero(0);
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
+
+    public function testItFailsWhenNegativeOrZeroIsPositive(): void
+    {
+        $user = $this->createValidUser();
+        $user->setNegativeOrZero(3);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('doit être un nombre négatif ou égal à zéro');
+
+        $this->validator->validate($user);
+    }
+
+    public function testItAllowsNullWhenNegativeOrZeroIsSet(): void
+    {
+        $user = $this->createValidUser();
+        $user->setNegativeOrZero(null);
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
+
     private function createValidUser(): User
     {
         $user = new User();

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -153,6 +153,38 @@ class ValidatorTest extends TestCase
         $this->assertTrue(true);
     }
 
+
+    public function testItPassesWhenPositiveConstraintIsSatisfied(): void
+    {
+        $user = $this->createValidUser();
+        $user->setPositive(10);
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
+
+    public function testItFailsWhenPositiveConstraintIsViolated(): void
+    {
+        $user = $this->createValidUser();
+        $user->setPositive(-5);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('doit être un nombre positif');
+
+        $this->validator->validate($user);
+    }
+
+    public function testItAllowsNullWhenPositiveConstraintIsSet(): void
+    {
+        $user = $this->createValidUser();
+        $user->setPositive(null);
+
+        $this->validator->validate($user);
+
+        $this->assertTrue(true);
+    }
+
     private function createValidUser(): User
     {
         $user = new User();


### PR DESCRIPTION
**Cette PR introduit quatre nouveaux validateurs numériques et met à jour la documentation en conséquence.**

#### Nouvelles annotations  
- `@Negative` — valide que la valeur est strictement inférieure à zéro.  
- `@NegativeOrZero` — valide que la valeur est inférieure ou égale à zéro.  
- `@Positive` — valide que la valeur est strictement supérieure à zéro.  
- `@PositiveOrZero` — valide que la valeur est supérieure ou égale à zéro.  

#### Comportement commun  
- Les validateurs ignorent les valeurs `null`.  
- Vérification préalable avec `is_numeric()` pour éviter les comparaisons invalides.  
- Lancement d’une `ValidationException` avec un message explicite en cas d’échec.  

#### Tests unitaires  
- Cas valides : valeurs dans la plage autorisée.  
- Cas invalides : valeurs hors contrainte et valeurs non numériques.  
- Cas neutres : `null` accepté.  

#### Documentation  
- Ajout des nouveaux validateurs